### PR TITLE
Contract suggestions, remove forced execution order fix which vote is used when calling `canPerform()`.

### DIFF
--- a/dandelion-voting/test/voting.js
+++ b/dandelion-voting/test/voting.js
@@ -42,15 +42,15 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
         RECOVER_DISALLOWED: 'RECOVER_DISALLOWED',
 
         // Voting errors
-        VOTING_NO_VOTE: "VOTING_NO_VOTE",
-        VOTING_INIT_PCTS: "VOTING_INIT_PCTS",
-        VOTING_CHANGE_SUPPORT_PCTS: "VOTING_CHANGE_SUPPORT_PCTS",
-        VOTING_CHANGE_QUORUM_PCTS: "VOTING_CHANGE_QUORUM_PCTS",
-        VOTING_INIT_SUPPORT_TOO_BIG: "VOTING_INIT_SUPPORT_TOO_BIG",
-        VOTING_CHANGE_SUPP_TOO_BIG: "VOTING_CHANGE_SUPP_TOO_BIG",
-        VOTING_CAN_NOT_VOTE: "VOTING_CAN_NOT_VOTE",
-        VOTING_CAN_NOT_EXECUTE: "VOTING_CAN_NOT_EXECUTE",
-        VOTING_CAN_NOT_FORWARD: "VOTING_CAN_NOT_FORWARD"
+        DANDELION_VOTING_NO_VOTE: "DANDELION_VOTING_NO_VOTE",
+        DANDELION_VOTING_INIT_PCTS: "DANDELION_VOTING_INIT_PCTS",
+        DANDELION_VOTING_CHANGE_SUPPORT_PCTS: "DANDELION_VOTING_CHANGE_SUPPORT_PCTS",
+        DANDELION_VOTING_CHANGE_QUORUM_PCTS: "DANDELION_VOTING_CHANGE_QUORUM_PCTS",
+        DANDELION_VOTING_INIT_SUPPORT_TOO_BIG: "DANDELION_VOTING_INIT_SUPPORT_TOO_BIG",
+        DANDELION_VOTING_CHANGE_SUPP_TOO_BIG: "DANDELION_VOTING_CHANGE_SUPP_TOO_BIG",
+        DANDELION_VOTING_CAN_NOT_VOTE: "DANDELION_VOTING_CAN_NOT_VOTE",
+        DANDELION_VOTING_CAN_NOT_EXECUTE: "DANDELION_VOTING_CAN_NOT_EXECUTE",
+        DANDELION_VOTING_CAN_NOT_FORWARD: "DANDELION_VOTING_CAN_NOT_FORWARD"
     })
 
     const voteDurationBlocks = 500
@@ -124,12 +124,12 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
         })
 
         it('fails changing required support lower than minimum acceptance quorum', async () => {
-            await assertRevert(voting.changeSupportRequiredPct(minimumAcceptanceQuorum.minus(1)), errors.VOTING_CHANGE_SUPPORT_PCTS)
+            await assertRevert(voting.changeSupportRequiredPct(minimumAcceptanceQuorum.minus(1)), errors.DANDELION_VOTING_CHANGE_SUPPORT_PCTS)
         })
 
         it('fails changing required support to 100% or more', async () => {
-            await assertRevert(voting.changeSupportRequiredPct(pct16(101)), errors.VOTING_CHANGE_SUPP_TOO_BIG)
-            await assertRevert(voting.changeSupportRequiredPct(pct16(100)), errors.VOTING_CHANGE_SUPP_TOO_BIG)
+            await assertRevert(voting.changeSupportRequiredPct(pct16(101)), errors.DANDELION_VOTING_CHANGE_SUPP_TOO_BIG)
+            await assertRevert(voting.changeSupportRequiredPct(pct16(100)), errors.DANDELION_VOTING_CHANGE_SUPP_TOO_BIG)
         })
 
         it('can change minimum acceptance quorum', async () => {
@@ -140,7 +140,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
         })
 
         it('fails changing minimum acceptance quorum to greater than min support', async () => {
-            await assertRevert(voting.changeMinAcceptQuorumPct(neededSupport.plus(1)), errors.VOTING_CHANGE_QUORUM_PCTS)
+            await assertRevert(voting.changeMinAcceptQuorumPct(neededSupport.plus(1)), errors.DANDELION_VOTING_CHANGE_QUORUM_PCTS)
         })
 
         it('can change vote buffer blocks', async () => {
@@ -161,7 +161,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
     })
 
-    for (const decimals of [0, 2, 18, 26]) {
+    for (const decimals of [0]) {
+    // for (const decimals of [0, 2, 18, 26]) {
         context(`normal token supply, ${decimals} decimals`, () => {
             const neededSupport = pct16(50)
             const minimumAcceptanceQuorum = pct16(20)
@@ -243,7 +244,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                 })
 
                 it('fails getting a vote out of bounds', async () => {
-                    await assertRevert(voting.getVote(voteId + 1), errors.VOTING_NO_VOTE)
+                    await assertRevert(voting.getVote(voteId + 1), errors.DANDELION_VOTING_NO_VOTE)
                 })
 
                 it('changing required support does not affect vote required support', async () => {
@@ -322,12 +323,12 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                 })
 
                 it('throws when non-holder votes', async () => {
-                    await assertRevert(voting.vote(voteId, true, { from: nonHolder }), errors.VOTING_CAN_NOT_VOTE)
+                    await assertRevert(voting.vote(voteId, true, { from: nonHolder }), errors.DANDELION_VOTING_CAN_NOT_VOTE)
                 })
 
                 it('throws when voting after voting closes', async () => {
                     await voting.mockAdvanceBlocks(voteDurationBlocks)
-                    await assertRevert(voting.vote(voteId, true, { from: holder29 }), errors.VOTING_CAN_NOT_VOTE)
+                    await assertRevert(voting.vote(voteId, true, { from: holder29 }), errors.DANDELION_VOTING_CAN_NOT_VOTE)
                 })
 
                 it("throws when voting before start block", async () => {
@@ -337,7 +338,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
                     assert(parseInt(newVoteStartBlock) > parseInt(currentBlock), "new vote start block should be ahead of current block")
 
-                    await assertRevert(voting.vote(newVoteId, true, { from: holder29 }), errors.VOTING_CAN_NOT_VOTE)
+                    await assertRevert(voting.vote(newVoteId, true, { from: holder29 }), errors.DANDELION_VOTING_CAN_NOT_VOTE)
                 })
 
                 it('can execute if vote is approved with support and quorum and execution delay has passed', async () => {
@@ -351,14 +352,14 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                 it('cannot execute vote if not enough quorum met', async () => {
                     await voting.vote(voteId, true, { from: holder20 })
                     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
-                    await assertRevert(voting.executeVote(voteId), errors.VOTING_CAN_NOT_EXECUTE)
+                    await assertRevert(voting.executeVote(voteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
                 })
 
                 it('cannot execute vote if not support met', async () => {
                     await voting.vote(voteId, false, { from: holder29 })
                     await voting.vote(voteId, false, { from: holder20 })
                     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
-                    await assertRevert(voting.executeVote(voteId), errors.VOTING_CAN_NOT_EXECUTE)
+                    await assertRevert(voting.executeVote(voteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
                 })
 
                 it('cannot execute vote before execution block', async () => {
@@ -367,17 +368,19 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                     await voting.vote(voteId, true, { from: holder29 })
                     await voting.vote(voteId, false, { from: holder20 })
                     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks - blocksSinceVoteCreation)
-                    await assertRevert(voting.executeVote(voteId), errors.VOTING_CAN_NOT_EXECUTE)
+                    await assertRevert(voting.executeVote(voteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
                 })
 
-                it('cannot execute vote before previous successful vote has executed', async () => {
-                    await voting.vote(voteId, true, { from: holder51 })
-                    await voting.mockAdvanceBlocks(bufferBlocks)
-                    const newVoteId = createdVoteId(await voting.newVote(script, 'metadata', true, { from: holder51 }));
-                    await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
 
-                    await assertRevert(voting.executeVote(newVoteId), errors.VOTING_CAN_NOT_EXECUTE)
-                })
+                // TODO: Fix test and behaviour!
+                // it('cannot execute vote before previous successful vote has executed', async () => {
+                //     await voting.vote(voteId, true, { from: holder51 })
+                //     await voting.mockAdvanceBlocks(bufferBlocks)
+                //     const newVoteId = createdVoteId(await voting.newVote(script, 'metadata', true, { from: holder51 }));
+                //     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
+                //
+                //     await assertRevert(voting.executeVote(newVoteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
+                // })
 
                 it('can execute vote once previous successful vote has executed', async () => {
                     await voting.vote(voteId, true, { from: holder51 })
@@ -405,17 +408,17 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                     await voting.vote(voteId, true, { from: holder51 })
                     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
                     await voting.executeVote(voteId)
-                    await assertRevert(voting.executeVote(voteId), errors.VOTING_CAN_NOT_EXECUTE)
+                    await assertRevert(voting.executeVote(voteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
                 })
 
                 it('cannot execute unvoted finished vote', async () => {
                     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
-                    await assertRevert(voting.executeVote(voteId), errors.VOTING_CAN_NOT_EXECUTE)
+                    await assertRevert(voting.executeVote(voteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
                 })
 
                 it("voter can't change vote", async () => {
                     await voting.vote(voteId, true, { from: holder29 })
-                    await assertRevert(voting.vote(voteId, false, { from: holder29 }), errors.VOTING_CAN_NOT_VOTE)
+                    await assertRevert(voting.vote(voteId, false, { from: holder29 }), errors.DANDELION_VOTING_CAN_NOT_VOTE)
                 })
 
                 it('cannot execute unvoted vote before start block', async () => {
@@ -424,7 +427,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                     const currentBlock = await voting.getBlockNumberPublic()
 
                     assert(parseInt(newVoteStartBlock) > parseInt(currentBlock), "new vote start block should be ahead of current block")
-                    await assertRevert(voting.executeVote(newVoteId), errors.VOTING_CAN_NOT_EXECUTE)
+                    await assertRevert(voting.executeVote(newVoteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
                 })
 
                 it("sets second vote start and snapshot block correctly when vote created before vote buffer elapsed", async () => {
@@ -516,101 +519,83 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
                 describe('ACLOracle canPerform()', () => {
 
-                    it('returns true when not voted in most recent vote', async () => {
-                        assert.isTrue(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                    it('returns true when not voted in any votes', async () => {
+                        assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns true when voted nay on most recent vote', async () => {
+                    it('returns true when voted nay on open vote', async () => {
                         await voting.vote(voteId, false, { from: holder29 })
 
-                        assert.isTrue(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns true when voted yea on most recent vote and vote finished but failed', async () => {
+                    it('returns true when voted yea and vote finished but failed', async () => {
                         await voting.vote(voteId, true, { from: holder20 })
                         await voting.vote(voteId, false, { from: holder29 })
                         await voting.mockAdvanceBlocks(voteDurationBlocks)
 
-                        assert.isTrue(await voting.canPerform(holder20, ANY_ADDR, "", []))
+                        assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder20]))
                     })
 
-                    it('returns true when voted yea on most recent vote and vote finished and executed', async () => {
+                    it('returns true when voted yea and vote finished and executed', async () => {
                         await voting.vote(voteId, true, { from: holder29 })
                         await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
                         await voting.executeVote(voteId)
 
-                        assert.isTrue(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns false when voted yea on most recent vote and vote finished but not executed', async () => {
+                    it('returns false when voted yea and vote finished but not executed', async () => {
                         await voting.vote(voteId, true, { from: holder29 })
                         await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
 
-                        assert.isFalse(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns false when voted yea on most recent vote and vote open', async () => {
+                    it('returns false when voted yea and vote open', async () => {
                         await voting.vote(voteId, true, { from: holder29 })
 
-                        assert.isFalse(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
                     it('returns false when voted nay on first vote and yea on second vote', async () => {
                         await voting.vote(voteId, false, { from: holder29 })
-                        assert.isTrue(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
 
                         voting.mockAdvanceBlocks(bufferBlocks)
                         const secondVoteId = createdVoteId(await voting.newVote(script, 'metadata', false))
                         await voting.vote(secondVoteId, true, { from: holder29 })
 
-                        assert.isFalse(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns true when voted yea on first vote and new vote created', async () => {
+                    it('returns false when voted yea on open vote and new vote created', async () => {
                         await voting.vote(voteId, true, { from: holder29 })
-                        assert.isFalse(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
 
                         voting.mockAdvanceBlocks(bufferBlocks)
                         createdVoteId(await voting.newVote(script, 'metadata', false))
 
-                        assert.isTrue(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns true when voted yea on first vote and nay on second vote', async () => {
+                    it('returns false when voted yea on first vote and nay on second vote', async () => {
                         await voting.vote(voteId, true, { from: holder29 })
-                        assert.isFalse(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
 
                         voting.mockAdvanceBlocks(bufferBlocks)
                         const secondVoteId = createdVoteId(await voting.newVote(script, 'metadata', false))
                         await voting.vote(secondVoteId, false, { from: holder29 })
 
-                        assert.isTrue(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns false when voted yea on most recent vote and address passed as param', async () => {
-                        await voting.vote(voteId, false, { from: holder20 })
-                        await voting.vote(voteId, true, { from: holder29 })
-
-                        // The following assert is to demonstrate that holder20 is not used
-                        // when evaluating canPerform() when passing address via param.
-                        assert.isTrue(await voting.canPerform(holder20, ANY_ADDR, "", []))
-
-                        assert.isFalse(await voting.canPerform(holder20, ANY_ADDR, "", [holder29]))
-                    })
-
-                    it('returns true when voted yea on most recent executed vote and address passed as param', async () => {
-                        await voting.vote(voteId, true, { from: holder29 })
-                        await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
-                        await voting.executeVote(voteId)
-
-                        // The following is to demonstrate that holder20 is not used when
-                        // evaluating canPerform() when passing address via param.
-                        const secondVoteId = createdVoteId(await voting.newVote(script, 'metadata', false, { from: holder20 }))
-                        await voting.vote(secondVoteId, true, { from: holder20 })
-                        assert.isFalse(await voting.canPerform(holder20, ANY_ADDR, "", []))
-
-                        assert.isTrue(await voting.canPerform(holder20, ANY_ADDR, "", [holder29]))
-                    })
+                    // it('returns false when voted yea on most recent vote and address passed as argument', async () => {
+                    //     await voting.vote(voteId, false, { from: holder20 })
+                    //     await voting.vote(voteId, true, { from: holder29 })
+                    //
+                    //     assert.isFalse(await voting.canPerform(holder29, ANY_ADDR, "", []))
+                    // })
                 })
             })
         })
@@ -624,13 +609,13 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
         it('fails if min acceptance quorum is greater than min support', async () => {
             const neededSupport = pct16(20)
             const minimumAcceptanceQuorum = pct16(50)
-            await assertRevert(voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, voteDurationBlocks, bufferBlocks, executionDelayBlocks), errors.VOTING_INIT_PCTS)
+            await assertRevert(voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, voteDurationBlocks, bufferBlocks, executionDelayBlocks), errors.DANDELION_VOTING_INIT_PCTS)
         })
 
         it('fails if min support is 100% or more', async () => {
             const minimumAcceptanceQuorum = pct16(20)
-            await assertRevert(voting.initialize(token.address, pct16(101), minimumAcceptanceQuorum, voteDurationBlocks, bufferBlocks, executionDelayBlocks), errors.VOTING_INIT_SUPPORT_TOO_BIG)
-            await assertRevert(voting.initialize(token.address, pct16(100), minimumAcceptanceQuorum, voteDurationBlocks, bufferBlocks, executionDelayBlocks), errors.VOTING_INIT_SUPPORT_TOO_BIG)
+            await assertRevert(voting.initialize(token.address, pct16(101), minimumAcceptanceQuorum, voteDurationBlocks, bufferBlocks, executionDelayBlocks), errors.DANDELION_VOTING_INIT_SUPPORT_TOO_BIG)
+            await assertRevert(voting.initialize(token.address, pct16(100), minimumAcceptanceQuorum, voteDurationBlocks, bufferBlocks, executionDelayBlocks), errors.DANDELION_VOTING_INIT_SUPPORT_TOO_BIG)
         })
     })
 
@@ -649,7 +634,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
             const [canVote] = await voting.getVote(voteId)
             assert.isFalse(canVote)
-            await assertRevert(voting.vote(voteId, true, { from: holder1 }), errors.VOTING_CAN_NOT_VOTE)
+            await assertRevert(voting.vote(voteId, true, { from: holder1 }), errors.DANDELION_VOTING_CAN_NOT_VOTE)
         })
     })
 
@@ -762,7 +747,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
         it('fails to forward actions before initialization', async () => {
             const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
             const script = encodeCallScript([action])
-            await assertRevert(voting.forward(script, { from: holder51 }), errors.VOTING_CAN_NOT_FORWARD)
+            await assertRevert(voting.forward(script, { from: holder51 }), errors.DANDELION_VOTING_CAN_NOT_FORWARD)
         })
     })
 

--- a/dandelion-voting/test/voting.js
+++ b/dandelion-voting/test/voting.js
@@ -379,39 +379,6 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                     await assertRevert(voting.executeVote(voteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
                 })
 
-
-                // TODO: Fix test and behaviour!
-                // it('cannot execute vote before previous successful vote has executed', async () => {
-                //     await voting.vote(voteId, true, { from: holder51 })
-                //     await voting.mockAdvanceBlocks(bufferBlocks)
-                //     const newVoteId = createdVoteId(await voting.newVote(script, 'metadata', true, { from: holder51 }));
-                //     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
-                //
-                //     await assertRevert(voting.executeVote(newVoteId), errors.DANDELION_VOTING_CAN_NOT_EXECUTE)
-                // })
-
-                it('can execute vote once previous successful vote has executed', async () => {
-                    await voting.vote(voteId, true, { from: holder51 })
-                    await voting.mockAdvanceBlocks(bufferBlocks)
-                    const newVoteId = createdVoteId(await voting.newVote(script, 'metadata', true, { from: holder51 }));
-                    await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
-
-                    await voting.executeVote(voteId)
-                    await voting.executeVote(newVoteId)
-
-                    assert.equal((await executionTarget.counter()).toNumber(), 4, 'should have executed script 4 times')
-                })
-
-                it('can execute vote if previous vote failed', async () => {
-                    await voting.mockAdvanceBlocks(bufferBlocks)
-                    const newVoteId = createdVoteId(await voting.newVote(script, 'metadata', true, { from: holder51 }));
-                    await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)
-
-                    await voting.executeVote(newVoteId)
-
-                    assert.equal((await executionTarget.counter()).toNumber(), 2, 'should have executed script 2 times')
-                })
-
                 it('cannot execute vote twice', async () => {
                     await voting.vote(voteId, true, { from: holder51 })
                     await voting.mockAdvanceBlocks(voteDurationBlocks + executionDelayBlocks)

--- a/dandelion-voting/test/voting.js
+++ b/dandelion-voting/test/voting.js
@@ -43,6 +43,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
         // Voting errors
         DANDELION_VOTING_NO_VOTE: "DANDELION_VOTING_NO_VOTE",
+        DANDELION_VOTING_VOTE_ID_ZERO: "DANDELION_VOTING_VOTE_ID_ZERO",
         DANDELION_VOTING_INIT_PCTS: "DANDELION_VOTING_INIT_PCTS",
         DANDELION_VOTING_CHANGE_SUPPORT_PCTS: "DANDELION_VOTING_CHANGE_SUPPORT_PCTS",
         DANDELION_VOTING_CHANGE_QUORUM_PCTS: "DANDELION_VOTING_CHANGE_QUORUM_PCTS",
@@ -248,6 +249,10 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
                 it('fails getting a vote out of bounds', async () => {
                     await assertRevert(voting.getVote(voteId + 1), errors.DANDELION_VOTING_NO_VOTE)
+                })
+
+                it('fails getting a vote with id 0', async () => {
+                    await assertRevert(voting.getVote(0), errors.DANDELION_VOTING_VOTE_ID_ZERO)
                 })
 
                 it('changing required support does not affect vote required support', async () => {
@@ -528,7 +533,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                     it('returns false when voted yea and vote finished, failed and before execution delay passed', async () => {
                         await voting.vote(voteId, true, { from: holder20 })
                         await voting.vote(voteId, false, { from: holder29 })
-                        await voting.mockAdvanceBlocks(durationBlocks + executionDelayBlocks - 3)
+                        await voting.mockAdvanceBlocks(durationBlocks + executionDelayBlocks - 4)
 
                         assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder20]))
                     })
@@ -541,7 +546,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                         assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns false when voted yea and vote finished but not executed', async () => {
+                    it('returns false when voted yea and vote finished but not executed and before execution period passed', async () => {
                         await voting.vote(voteId, true, { from: holder29 })
                         await voting.mockAdvanceBlocks(durationBlocks + executionDelayBlocks)
 

--- a/dandelion-voting/test/voting.js
+++ b/dandelion-voting/test/voting.js
@@ -165,8 +165,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
     })
 
-    for (const decimals of [0]) {
-    // for (const decimals of [0, 2, 18, 26]) {
+    for (const decimals of [0, 2, 18, 26]) {
         context(`normal token supply, ${decimals} decimals`, () => {
             const neededSupport = pct16(50)
             const minimumAcceptanceQuorum = pct16(20)
@@ -518,12 +517,20 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                         assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder29]))
                     })
 
-                    it('returns true when voted yea and vote finished but failed', async () => {
+                    it('returns true when voted yea and vote finished, failed and execution delay passed', async () => {
                         await voting.vote(voteId, true, { from: holder20 })
                         await voting.vote(voteId, false, { from: holder29 })
-                        await voting.mockAdvanceBlocks(durationBlocks)
+                        await voting.mockAdvanceBlocks(durationBlocks + executionDelayBlocks)
 
                         assert.isTrue(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder20]))
+                    })
+
+                    it('returns false when voted yea and vote finished, failed and before execution delay passed', async () => {
+                        await voting.vote(voteId, true, { from: holder20 })
+                        await voting.vote(voteId, false, { from: holder29 })
+                        await voting.mockAdvanceBlocks(durationBlocks + executionDelayBlocks - 3)
+
+                        assert.isFalse(await voting.canPerform(ANY_ADDR, ANY_ADDR, "", [holder20]))
                     })
 
                     it('returns true when voted yea and vote finished and executed', async () => {


### PR DESCRIPTION
Added contract suggestions from @bingen. 

Removed forced execution order for votes. Each vote can still only be executed at least `bufferBlocks` after the previous votes execution time (with the potential exception of a period during which `bufferBlocks` is changed). However, we no longer check the previous vote has executed before allowing the current one to execute.

Fixed which vote is used in `canPerform()`. Initially the vote used was the latest created vote, but it should have been the last vote the sender voted yes on. 

Updated naming to be more consistent.