### PR TITLE
Rename date picker component

### DIFF
--- a/app/src/screens/Votes.js
+++ b/app/src/screens/Votes.js
@@ -7,7 +7,7 @@ import {
   textStyle,
   useLayout,
   useTheme,
-  _DateRange as DateRange,
+  DateRangePicker,
 } from '@aragon/ui'
 import EmptyFilteredVotes from '../components/EmptyFilteredVotes'
 import VoteCard from '../components/VoteCard/VoteCard'
@@ -136,7 +136,7 @@ const Votes = React.memo(function Votes({
               ]}
               width="128px"
             />
-            <DateRange
+            <DateRangePicker
               startDate={voteDateRangeFilter.start}
               endDate={voteDateRangeFilter.end}
               onChange={handleVoteDateRangeFilterChange}


### PR DESCRIPTION
Since the new release of @aragon/ui@1.0.0 the `DateRange` component has been renamed to `DateRangePicker`