### PR TITLE
Update apm staging registry

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -6,8 +6,8 @@
       "appName": "dandelion-voting.open.aragonpm.eth"
     },
     "staging": {
-      "registry": "0x98Df287B6C145399Aaa709692c8D308357bC085D",
-      "appName": "dandelion-voting-staging.open.aragonpm.eth",
+      "registry": "0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939",
+      "appName": "dandelion-voting.open.aragonpm.eth",
       "network": "rinkeby"
     },
     "rinkeby": {


### PR DESCRIPTION
APM Staging registry has been updated so we can use it now instead of using the traditional rinkeby apm repo with the staging tag on the package name