### PR TITLE
Update rinkeby and mainnet appNames

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -12,7 +12,7 @@
     },
     "rinkeby": {
       "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",
-      "appName": "dandelion-voting.open.aragonpm.eth",
+      "appName": "dandelion-voting.aragonpm.eth",
       "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
       "network": "rinkeby"
     },
@@ -23,7 +23,7 @@
     },
     "mainnet": {
       "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
-      "appName": "dandelion-voting.open.aragonpm.eth",
+      "appName": "dandelion-voting.aragonpm.eth",
       "network": "mainnet"
     }
   },


### PR DESCRIPTION
Removes `.open` from app name